### PR TITLE
Enable attributes in classic mode, add strikeout

### DIFF
--- a/src/FarEditor.cpp
+++ b/src/FarEditor.cpp
@@ -1197,16 +1197,18 @@ FarColor FarEditor::convert(const StyledRegion* rd) const
     if (rd->isBackSet) {
       col.BackgroundColor = rd->back;
     }
-    if (TrueMod) {
-      if (rd->style & StyledRegion::RD_BOLD) {
-        col.Flags |= FCF_FG_BOLD;
-      }
-      if (rd->style & StyledRegion::RD_ITALIC) {
-        col.Flags |= FCF_FG_ITALIC;
-      }
-      if (rd->style & StyledRegion::RD_UNDERLINE) {
-        col.Flags |= FCF_FG_UNDERLINE;
-      }
+
+    if (rd->style & StyledRegion::RD_BOLD) {
+      col.Flags |= FCF_FG_BOLD;
+    }
+    if (rd->style & StyledRegion::RD_ITALIC) {
+      col.Flags |= FCF_FG_ITALIC;
+    }
+    if (rd->style & StyledRegion::RD_UNDERLINE) {
+      col.Flags |= FCF_FG_UNDERLINE;
+    }
+    if (rd->style & StyledRegion::RD_STRIKEOUT) {
+      col.Flags |= FCF_FG_STRIKEOUT;
     }
   }
 


### PR DESCRIPTION
- There's no need to guard text attributes with `if (TrueMod)`.
- Added RD_STRIKEOUT processing. There's [more](https://github.com/colorer/FarColorer/blob/2c5c683e575fa974f95f9431624b3589a6ec132c/external/far3sdk/plugin.hpp#L76-L80) in Far, but [not in Colorer](https://github.com/colorer/Colorer-library/blob/67630ffaca788f50d94b624ca7f4384c3cb81cd6/src/colorer/handlers/StyledRegion.h#L15).