### PR TITLE
Disable transparency

### DIFF
--- a/src/FarEditor.cpp
+++ b/src/FarEditor.cpp
@@ -1219,9 +1219,7 @@ FarColor FarEditor::convert(const StyledRegion* rd) const
     col.ForegroundColor = revertRGB(col.ForegroundColor);
     col.BackgroundColor = revertRGB(col.BackgroundColor);
   }
-  // set transparency to off
-  col.BackgroundRGBA.a = 0xFF;
-  col.ForegroundRGBA.a = 0xFF;
+
   return col;
 }
 
@@ -1256,6 +1254,8 @@ void FarEditor::addFARColor(intptr_t lno, intptr_t s, intptr_t e, const FarColor
   ec.Owner = MainGuid;
   ec.Priority = 0;
   ec.Color = col;
+  MAKE_OPAQUE(ec.Color.BackgroundColor);
+  MAKE_OPAQUE(ec.Color.ForegroundColor);
   info->EditorControl(editor_id, ECTL_ADDCOLOR, 0, &ec);
 }
 


### PR DESCRIPTION
Looks like the changes introduced in a3e75d5945daa4f4cb810a5a0df5dcc799668d97 don't cover all the cases:

![image](https://user-images.githubusercontent.com/11453922/121955548-00d97700-cd58-11eb-8707-f2f0d9070478.png)

I've moved transparency setting to the only function that invokes `ECTL_ADDCOLOR`, that should cover everything.
