### PR TITLE
Disable 7-zip shenanigans

### DIFF
--- a/.github/workflows/farcolorer-release.yml
+++ b/.github/workflows/farcolorer-release.yml
@@ -101,9 +101,9 @@ jobs:
         working-directory: build
         shell: bash
         run: |
-          7z a ${{ env.farcolorer_name }} ./install/FarColorer/*
-          7z a ${{ env.farcolorer_withoutbase_name }} ./install/FarColorer/* -x!./install/FarColorer/base
-          7z a ${{ env.farcolorer_pdb_name }} ./src/colorer.pdb
+          7z a -m0=LZMA -mf=BCJ2 -mx9 ${{ env.farcolorer_name }} ./install/FarColorer/*
+          7z a -m0=LZMA -mf=BCJ2 -mx9 ${{ env.farcolorer_withoutbase_name }} ./install/FarColorer/* -x!./install/FarColorer/base
+          7z a -m0=LZMA -mf=off -mx9 ${{ env.farcolorer_pdb_name }} ./src/colorer.pdb
 
       - name: Upload result to cache
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
In v23 7-zip introduced a new filter for ARM64 binaries, incompatible with all previous versions and enabled by default.
Igor Pavlov [does not think it is a big problem](https://sourceforge.net/p/sevenzip/discussion/45797/thread/3f550826d8/#384e/f27d), but not everyone is on v23 yet, [including our CI](https://ci.appveyor.com/project/FarGroup/farmanager/builds/47582819/job/qg8xvpsk57je3941#L2045). 
Also, I don't think we should require users to have the very latest 7-zip just to unpack the distribution.

The proposed change sets the filter to BCJ2 for all 7z but the one with PDBs (where "off" seemingly works better) and sets compression method to LZMA for maximum compatibility.
